### PR TITLE
feat: add social posts section

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
     </a>
     <nav class="space-x-6 text-gray-700 text-base font-medium">
       <a href="#programs" class="hover:text-blue-600 transition-colors duration-300">Programs</a>
+      <a href="#posts" class="hover:text-blue-600 transition-colors duration-300">Posts</a>
       <a href="https://pledge.mentor-x.org/" target="_blank" rel="noopener noreferrer" class="hover:text-blue-600 transition-colors duration-300">Donate</a>
       <a href="mailto:admin@mentor-x.org" class="hover:text-blue-600 transition-colors duration-300">Contact Us</a>
     </nav>
@@ -75,6 +76,29 @@
 
 <!-- Spacer -->
 <section class="h-24 md:h-32 bg-gradient-to-b from-white to-gray-50"></section>
+
+<!-- Posts -->
+<section id="posts" class="py-20 bg-gray-100">
+  <div class="container mx-auto px-6 md:px-12 flex flex-col items-center gap-8">
+    <h2 class="text-3xl md:text-4xl font-bold text-blue-800 mb-6">Posts</h2>
+    <div class="flex flex-col md:flex-row gap-4">
+      <a href="https://mentor-x.blogspot.com/" target="_blank" rel="noopener noreferrer"
+         class="px-6 py-3 bg-blue-500 text-white text-lg font-medium rounded-full shadow-md hover:bg-blue-600 transition-colors duration-300">
+        MentorX Blog
+      </a>
+      <a href="https://x.com/XMentor18812" target="_blank" rel="noopener noreferrer"
+         class="px-6 py-3 bg-blue-500 text-white text-lg font-medium rounded-full shadow-md hover:bg-blue-600 transition-colors duration-300">
+        Follow Us on X
+      </a>
+    </div>
+    <div class="w-full max-w-2xl">
+      <a class="twitter-timeline" data-tweet-limit="3" href="https://x.com/XMentor18812?ref_src=twsrc%5Etfw">Tweets by XMentor18812</a>
+    </div>
+  </div>
+</section>
+
+<!-- Spacer -->
+<section class="h-24 md:h-32 bg-gradient-to-b from-gray-100 to-white"></section>
 
 <!-- Our Mission -->
 <section id="mission" class="mission-bg py-20 scroll-mt-24">
@@ -181,6 +205,8 @@
     <div class="space-x-4 text-orange-400 text-lg">
       <a href="#programs" class="hover:underline">Programs</a>
       <span>|</span>
+      <a href="#posts" class="hover:underline">Posts</a>
+      <span>|</span>
       <a href="https://pledge.mentor-x.org/" target="_blank" rel="noopener noreferrer" class="hover:underline">Donate</a>
       <span>|</span>
       <a href="mailto:admin@mentor-x.org" class="hover:underline">Contact Us</a>
@@ -197,6 +223,9 @@
     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
   </svg>
 </button>
+
+<!-- Twitter Embed Script -->
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 <!-- Animation Script -->
 <script>


### PR DESCRIPTION
## Summary
- add Posts navigation link and section
- include buttons to MentorX blog and X profile
- embed latest three X posts via Twitter timeline
- add Posts link to footer for consistent navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897ba40b07883329db7b792e2194c42