### PR TITLE
Simplify tweet loading and match posts styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # Mentor-X
+
+Landing page for the MentorX community.
+
+## Tweet Loading
+
+Tweets from [@XMentor18812](https://x.com/XMentor18812) are embedded using Twitter's official timeline widget. This keeps implementation simple and avoids extra network requests.
+
+1. Add an anchor tag with the `twitter-timeline` class inside a styled container:
+
+   ```html
+   <div class="w-full max-w-2xl overflow-hidden rounded shadow bg-white p-4">
+     <a class="twitter-timeline" data-tweet-limit="3" href="https://x.com/XMentor18812?ref_src=twsrc%5Etfw">Tweets by XMentor18812</a>
+   </div>
+   ```
+
+2. Include Twitter's widget script once at the end of the page:
+
+   ```html
+   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+   ```
+
+3. Tailor the feed by adjusting the `data-tweet-limit` or other [widget options](https://developer.twitter.com/en/docs/twitter-for-websites/timelines/overview). The surrounding `<div>` uses Tailwind classes for styling, matching the Blogger post list.
+
+This replaces previous custom fetch solutions and ensures only the official timeline loads.
+

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
 <section id="posts" class="py-20 bg-gray-100">
   <div class="container mx-auto px-6 md:px-12 flex flex-col items-center gap-8">
     <h2 class="text-3xl md:text-4xl font-bold text-blue-800 mb-6">Posts</h2>
-    <div class="w-full max-w-2xl overflow-hidden rounded-lg mb-6">
+    <div class="w-full max-w-2xl overflow-hidden rounded shadow bg-white p-4 mb-6">
       <a class="twitter-timeline" data-tweet-limit="3" href="https://x.com/XMentor18812?ref_src=twsrc%5Etfw">Tweets by XMentor18812</a>
     </div>
     <div class="flex flex-col md:flex-row gap-4">


### PR DESCRIPTION
## Summary
- Use only Twitter's official timeline widget for tweets and style it like Blogger post cards
- Document the tweet loading approach and customization steps in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d0e5b44708332a2695417790b2df1